### PR TITLE
When using help, append --help to target command

### DIFF
--- a/src/ign.in
+++ b/src/ign.in
@@ -215,8 +215,9 @@ if ARGV[0].eql? 'help'
     exit(0)
   end
 
-  # Remove the help command.
+  # Remove the help command and append --help.
   ARGV.delete_at(0)
+  ARGV.append('--help')
 end
 
 version_index = 0


### PR DESCRIPTION
This fixes a minor bug that occurs when inputting `ign help gazebo` which launches gazebo instead of printing help information.

I tested this on the following set of commands, `topic service sdf gui msg fuel launch log` without issue.