### PR TITLE
Fix syntax error caused by missing comma.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -96,7 +96,7 @@ ruby_binary(
         ":fuel",
         ":gui",
         ":gazebo",
-        ":launch"
+        ":launch",
         "//ign_launch",
         "//ign_launch:ign-launch-plugins",
         "//ign_gui:ign_gui",


### PR DESCRIPTION
I assume this is just an oversight but it's been over a year since I've looked at bazel build files so maybe this comma was strategically absent. But it's causing a syntax error when I try the reference build:

```
ERROR: /ignition/ign_tools/BUILD.bazel:100:9: syntax error at '"//ign_launch"': expected ]
ERROR: package contains errors: ign_tools
DEBUG: /ignition/ign_bazel/qt.bzl:86:14: src/gui/GuiFileHandler.hh gui/GuiFileHandler.hh
DEBUG: /ignition/ign_bazel/qt.bzl:86:14: include/ignition/gazebo/gui/Gui.hh ignition/gazebo/gui/Gui.hh
DEBUG: /ignition/ign_bazel/qt.bzl:86:14: include/ignition/gazebo/gui/GuiEvents.hh ignition/gazebo/gui/GuiEvents.hh
DEBUG: /ignition/ign_bazel/qt.bzl:86:14: include/ignition/gazebo/gui/GuiRunner.hh ignition/gazebo/gui/GuiRunner.hh
DEBUG: /ignition/ign_bazel/qt.bzl:86:14: include/ignition/gazebo/gui/GuiSystem.hh ignition/gazebo/gui/GuiSystem.hh
DEBUG: /ignition/ign_bazel/qt.bzl:86:14: include/ignition/gazebo/gui/TmpIface.hh ignition/gazebo/gui/TmpIface.hh
ERROR: error loading package 'ign_tools': Package 'ign_tools' contains errors
```