### PR TITLE
Clean up ignition-tools.pc file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,11 +250,17 @@ else (build_errors)
 
   ########################################
   # Make the package config files
+  set(PC_CONFIG_INSTALL_DIR ${LIB_INSTALL_DIR}/pkgconfig)
+  file(RELATIVE_PATH
+    PC_CONFIG_RELATIVE_PATH_TO_PREFIX
+    "${CMAKE_INSTALL_PREFIX}/${PC_CONFIG_INSTALL_DIR}"
+    "${CMAKE_INSTALL_PREFIX}"
+  )
   configure_file(
     ${CMAKE_SOURCE_DIR}/cmake/pkgconfig/ignition.in
     ${CMAKE_CURRENT_BINARY_DIR}/cmake/pkgconfig/${PROJECT_NAME_LOWER}.pc @ONLY)
   install(FILES ${CMAKE_CURRENT_BINARY_DIR}/cmake/pkgconfig/${PROJECT_NAME_LOWER}.pc
-    DESTINATION ${LIB_INSTALL_DIR}/pkgconfig
+    DESTINATION ${PC_CONFIG_INSTALL_DIR}
     COMPONENT pkgconfig)
 
   ########################################

--- a/cmake/pkgconfig/ignition.in
+++ b/cmake/pkgconfig/ignition.in
@@ -1,5 +1,5 @@
-prefix=${pcfiledir}/../..
-libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+prefix=${pcfiledir}/@PC_CONFIG_RELATIVE_PATH_TO_PREFIX@
+libdir=${prefix}/@LIB_INSTALL_DIR@
 includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 
 Name: Ignition @IGN_PROJECT_NAME@

--- a/cmake/pkgconfig/ignition.in
+++ b/cmake/pkgconfig/ignition.in
@@ -6,5 +6,5 @@ Name: Ignition @IGN_PROJECT_NAME@
 Description: A set of @IGN_PROJECT_NAME@ classes for robot applications
 Version: @PROJECT_VERSION_FULL@
 Requires:
-Libs: -L${libdir} -l@PROJECT_NAME_LOWER@
-CFlags: -I${includedir}
+Libs:
+CFlags:

--- a/cmake/pkgconfig/ignition.in
+++ b/cmake/pkgconfig/ignition.in
@@ -1,10 +1,3 @@
-prefix=${pcfiledir}/@PC_CONFIG_RELATIVE_PATH_TO_PREFIX@
-libdir=${prefix}/@LIB_INSTALL_DIR@
-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
-
 Name: Ignition @IGN_PROJECT_NAME@
 Description: A set of @IGN_PROJECT_NAME@ classes for robot applications
 Version: @PROJECT_VERSION_FULL@
-Requires:
-Libs:
-CFlags:

--- a/cmake/pkgconfig/ignition.in
+++ b/cmake/pkgconfig/ignition.in
@@ -1,3 +1,4 @@
+# This packages provides no headers or libraries, so those fields are omitted
 Name: Ignition @IGN_PROJECT_NAME@
 Description: A set of @IGN_PROJECT_NAME@ classes for robot applications
 Version: @PROJECT_VERSION_FULL@


### PR DESCRIPTION
# 🦟 Bug fix

Fixes minor problem introduced by #30 

## Summary

We merged #30 to make our cmake and `.pc` config files relocatable. That PR was merged before we noticed an issue in a similar PR: https://github.com/ignitionrobotics/ign-cmake/pull/129. The problem is the hard-coded `../..` path to prefix from `pcfiledir` is incorrect when the `.pc` file is installed to a subfolder of lib, such as for Ubuntu debian packages on amd64, which install to `/usr/lib/x86_64-linux-gnu/pkgconfig`. This PR includes the fix that was used for ign-cmake.

I also noticed that we have include and linker flags for this package in the `.pc` file even though it has no libraries or header files. So I've removed those files as well. Of course, now the `.pc` file is  basically a no-op, but I'd rather have the correct relocatable path logic even if it's not used.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**