### PR TITLE
Fix CMake warning and error message types

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,11 +206,11 @@ endif()
 #################################################
 # Print warnings and errors
 if ( build_warnings )
-  message(STATUS "BUILD WARNINGS")
+  message(WARNING "BUILD WARNINGS")
   foreach (msg ${build_warnings})
-    message(STATUS ${msg})
+    message(WARNING ${msg})
   endforeach ()
-  message(STATUS "END BUILD WARNINGS\n")
+  message(WARNING "END BUILD WARNINGS\n")
 endif (build_warnings)
 
 ########### Add uninstall target ###############
@@ -223,11 +223,11 @@ add_custom_target(uninstall
   "${CMAKE_CURRENT_BINARY_DIR}/cmake/cmake_uninstall.cmake")
 
 if (build_errors)
-  message(STATUS "BUILD ERRORS: These must be resolved before compiling.")
+  message(SEND_ERROR "BUILD ERRORS: These must be resolved before compiling.")
   foreach (msg ${build_errors})
-    message(STATUS ${msg})
+    message(SEND_ERROR ${msg})
   endforeach ()
-  message(STATUS "END BUILD ERRORS\n")
+  message(SEND_ERROR "END BUILD ERRORS\n")
   message (FATAL_ERROR "Errors encountered in build. "
       "Please see the BUILD ERRORS above.")
 else (build_errors)


### PR DESCRIPTION
# 🦟 Bug fix

Fix CMake warning and error message types, so that they're printed to the terminal during the build.

## Summary
In a fresh build when I don't have all the dependencies, I'm getting a line that tells me to see BUILD ERRORS above, but there's nothing printed "above."
It's a dependency error, and it's only printed in stdout and not stderr.
So unless I have convenient access to the log directory (which I don't when building from a Dockerfile), I wouldn't know what package was missing without digging.

```
Step 15/15 : RUN cd ${IGN_WS}  && colcon build --merge-install --cmake-args -DBUILD_TESTING=OFF
 ---> Running in 623c9c1ecab6
Starting >>> ignition-cmake2
Starting >>> ignition-tools
Finished <<< ignition-cmake2 [1.23s]
Starting >>> ignition-math6
--- stderr: ignition-tools
CMake Error at CMakeLists.txt:231 (message):
  Errors encountered in build.  Please see the BUILD ERRORS above.


---
Failed   <<< ignition-tools [1.27s, exited with code 1]
Aborted  <<< ignition-math6 [1.72s]

Summary: 1 package finished [3.30s]
  1 package failed: ignition-tools
  1 package aborted: ignition-math6
  2 packages had stderr output: ignition-math6 ignition-tools
  12 packages not processed
The command '/bin/sh -c cd ${IGN_WS}  && colcon build --merge-install --cmake-args -DBUILD_TESTING=OFF' returned a non-zero code: 1
```

Upon entering the container and checking, `log/latest/ignition-tools/stderr.log` only has two lines:
```
CMake Error at CMakeLists.txt:231 (message):
  Errors encountered in build.  Please see the BUILD ERRORS above.
```

whereas `stdout.log` has these lines:
```
-- BUILD WARNINGS
--  ronn not found, manpages won't be generated
-- END BUILD WARNINGS

-- BUILD ERRORS: These must be resolved before compiling.
--  Missing: ruby (ruby)
-- END BUILD ERRORS

-- Configuring incomplete, errors occurred!
See also "/home/developer/ign_ws/build/ignition-tools/CMakeFiles/CMakeOutput.log".
```

After the fix, the output looks like:
```
$ colcon build --merge-install --cmake-args -DBUILD_TESTING=OFF
Starting >>> ignition-cmake2
Starting >>> ignition-tools
--- stderr: ignition-tools
CMake Warning at CMakeLists.txt:209 (message):
  BUILD WARNINGS


CMake Warning at CMakeLists.txt:211 (message):
    ronn not found, manpages won't be generated


CMake Warning at CMakeLists.txt:213 (message):
  END BUILD WARNINGS



CMake Error at CMakeLists.txt:226 (message):
  BUILD ERRORS: These must be resolved before compiling.


CMake Error at CMakeLists.txt:228 (message):
    Missing: ruby (ruby)


CMake Error at CMakeLists.txt:230 (message):
  END BUILD ERRORS



CMake Error at CMakeLists.txt:231 (message):
  Errors encountered in build.  Please see the BUILD ERRORS above.


---
Failed   <<< ignition-tools [0.13s, exited with code 1]
Aborted  <<< ignition-cmake2 [0.46s]
```


## Checklist
- [x] Signed all commits for DCO
- [ ] ~~Added tests~~
- [ ] ~~Updated documentation (as needed)~~
- [ ] ~~Updated migration guide (as needed)~~
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**