### PR TITLE
Use ; as IGN_CONFIG_PATH delimiter on windows

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,11 @@
 include (${project_cmake_dir}/Utils.cmake)
 
+# Set delimiter for environment variables with multiple path values based on OS
+if (WIN32)
+  set(ENV_PATH_DELIMITER ";")
+else()
+  set(ENV_PATH_DELIMITER ":")
+endif()
+
 configure_file(ign.in ${PROJECT_BINARY_DIR}/ign)
 install (PROGRAMS ${PROJECT_BINARY_DIR}/ign DESTINATION ${BIN_INSTALL_DIR})

--- a/src/ign.in
+++ b/src/ign.in
@@ -34,7 +34,7 @@ yaml_found = false
 
 conf_dirs = '@CMAKE_INSTALL_PREFIX@/share/ignition/'
 conf_dirs = ENV['IGN_CONFIG_PATH'] if ENV.key?('IGN_CONFIG_PATH')
-conf_dirs = conf_dirs.split(':')
+conf_dirs = conf_dirs.split('@ENV_PATH_DELIMITER@')
 
 conf_dirs.each do |conf_directory|
   next if Dir.glob(conf_directory + '/*.yaml').empty?


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #43 

## Summary

The `ign` tool looks in the `IGN_CONFIG_PATH` environment variable for a `:` delimited list of paths to search for ignition command files. Since Windows paths have `:` (for example `C:\`), this logic incorrectly splits windows paths.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
