### PR TITLE
Sort versions correctly.

### DIFF
--- a/src/ign.in
+++ b/src/ign.in
@@ -142,7 +142,7 @@ end
 # versions go first.
 sorted_commands = {}
 commands.each do |cmd, versions|
-  sorted_commands[cmd] = versions.sort_by { |k, v|
+  sorted_commands[cmd] = versions.sort_by { |k, _v|
     # Prereleases include the "~" symbol. However Gem::Version doesn't support
     # it, so we remove it.
     k = k.tr('~', '')

--- a/src/ign.in
+++ b/src/ign.in
@@ -142,7 +142,12 @@ end
 # versions go first.
 sorted_commands = {}
 commands.each do |cmd, versions|
-  sorted_commands[cmd] = versions.sort.reverse
+  sorted_commands[cmd] = versions.sort_by { |k, v|
+    # Prereleases include the "~" symbol. However Gem::Version doesn't support
+    # it, so we remove it.
+    k = k.tr('~', '')
+    Gem::Version.new(k)
+  }.reverse
 end
 
 # Commands is a hash where the key is the command and the value is a list.

--- a/src/ign.in
+++ b/src/ign.in
@@ -142,12 +142,12 @@ end
 # versions go first.
 sorted_commands = {}
 commands.each do |cmd, versions|
-  sorted_commands[cmd] = versions.sort_by { |k, _v|
+  sorted_commands[cmd] = versions.sort_by do |k, _v|
     # Prereleases include the "~" symbol. However Gem::Version doesn't support
     # it, so we remove it.
     k = k.tr('~', '')
     Gem::Version.new(k)
-  }.reverse
+  end.reverse
 end
 
 # Commands is a hash where the key is the command and the value is a list.


### PR DESCRIPTION
Signed-off-by: Carlos Agüero <caguero@openrobotics.org>

<!-- 
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://ignitionrobotics.org/docs/all/contributing
-->

# 🦟 Bug fix

Fixes #48 

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

Before this patch, `ign` was sorting all library versions alphabetically. Thus, version `10.0.0` was considered lower than `2.0.0`. This should be fixed now.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [X] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

