### PR TITLE
add x86 check to findSSE.cmake

### DIFF
--- a/cmake/FindSSE.cmake
+++ b/cmake/FindSSE.cmake
@@ -1,6 +1,6 @@
 # Check if SSE instructions are available on the machine where 
 # the project is compiled.
-
+IF(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64")
 IF(CMAKE_SYSTEM_NAME MATCHES "Linux")
    EXEC_PROGRAM(cat ARGS "/proc/cpuinfo" OUTPUT_VARIABLE CPUINFO)
 
@@ -96,7 +96,7 @@ ELSE(CMAKE_SYSTEM_NAME MATCHES "Linux")
    set(SSSE3_FOUND  false CACHE BOOL "SSSE3 available on host")
    set(SSE4_1_FOUND false CACHE BOOL "SSE4.1 available on host")
 ENDIF(CMAKE_SYSTEM_NAME MATCHES "Linux")
-
+ENDIF(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64")
 if(NOT SSE2_FOUND)
       MESSAGE(STATUS "Could not find hardware support for SSE2 on this machine.")
 endif(NOT SSE2_FOUND)


### PR DESCRIPTION
SSE is only supported on x86 family processors. This disables looking for it on other platforms such as ARM64. Perhaps it would be nicer to skip this check altogether in the root CMakeLists.txt

<!-- 
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://ignitionrobotics.org/docs/all/contributing
-->

# 🦟 Bug fix

Fixes #51

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->
Adds IF(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64") clause to CMake/findSSE.cmake to disable looking for SSE on non-x86 hardware systems. Fixes configure error.

**Note to maintainers**: Remember to use **Squash-Merge**
