### PR TITLE
Permit to invoke ign command in Windows

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -54,6 +54,17 @@ configure_file(ign.in ${ign_script_configured})
 file(GENERATE OUTPUT ${ign_script_generated} INPUT ${ign_script_configured})
 install (PROGRAMS ${ign_script_generated} DESTINATION ${BIN_INSTALL_DIR})
 
+if(WIN32)
+  # On Windows also install the executable as ign 
+  # to permit to invoke ign via Git Bash 
+  # see https://github.com/ignitionrobotics/ign-tools/issues/70
+  install (PROGRAMS ${ign_script_generated} DESTINATION ${BIN_INSTALL_DIR} RENAME ign)
+  
+  # On Windows also install the ign.bat wrapper script to permit to
+  # invoke ign via Command Prompt or Powershell
+  install (PROGRAMS ign.bat DESTINATION ${BIN_INSTALL_DIR})
+endif()
+
 #===============================================================================
 # BEGIN TEST ign command
 # Generate the ruby script for internal testing.

--- a/src/ign.bat
+++ b/src/ign.bat
@@ -1,0 +1,6 @@
+@echo off
+REM %~dp0 is the directory in which this bat script is, see
+REM https://stackoverflow.com/questions/112055/what-does-d0-mean-in-a-windows-batch-file
+REM %* redirects the arguments to the output, see 
+REM https://serverfault.com/questions/22443/do-windows-batch-files-have-a-construction/22541#22541
+ruby %~dp0\ign %*


### PR DESCRIPTION
# 🦟 Bug fix

Fixes https://github.com/ignitionrobotics/ign-tools/issues/70 .

## Summary

The fix is described in https://github.com/ignitionrobotics/ign-tools/issues/70#issue-1039724662 .

Before this PR, if you invoked `ign` on Windows in Command Prompt, Powershell or Git Bash nothing happened. After this PR, ign will properly execute.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
