### PR TITLE
Fix .dll installation directory on Windows

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -34,7 +34,10 @@ if(MSVC)
   target_compile_options(backward PUBLIC /wd4267)
   target_compile_options(backward PUBLIC /wd4996)
 endif()
-install (TARGETS backward DESTINATION ${LIB_INSTALL_DIR})
+install (TARGETS backward 
+         LIBRARY DESTINATION ${LIB_INSTALL_DIR}
+         ARCHIVE DESTINATION ${LIB_INSTALL_DIR} 
+         RUNTIME DESTINATION ${BIN_INSTALL_DIR})
 
 #===============================================================================
 # Used for the installed version.


### PR DESCRIPTION

# 🦟 Bug fix

Fix  .dll installation directory on Windows .


## Summary

On Windows, `.dll` libraries are tipically installed in `<prefix>/bin`, while before this fix, the `.dll`  libraries were installed by this project in `<prefix>/lib`, resulting the warning:
~~~
Library error: ignition-tools-backward.dll not found. Improved backtrace generation will be disabled
~~~

When the `ign` command was used, as `ignition-tools-backward.dll` was not found in the directory in which ruby's function to find dll libraries was looking into.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
