### PR TITLE
Add bash-completion helper for command names

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,13 @@ cmake .. -DCMAKE_INSTALL_PREFIX=/usr
 sudo make install
 ```
 
+### Bash auto-completion
+
+Source the [etc/ign.bash_completion.sh](etc/ign.bash_completion.sh) script in your bash terminal window to enable auto-complete:
+~~~
+. etc/ign.bash_completion.sh
+~~~
+
 ### Uninstallation
 
 To uninstall the software installed with the previous steps:

--- a/etc/ign.bash_completion.sh
+++ b/etc/ign.bash_completion.sh
@@ -1,0 +1,35 @@
+# ign bash completion
+
+function _ign
+{
+  local prev cur cmd opts
+  local ign="$1"
+  COMPREPLY=()
+  cur="$2"
+  prev="$3"
+
+  # searching for the command
+  for ((i=1; $i<=$COMP_CWORD; i++)); do
+    if [[ ${COMPWORDS[i]} != -* ]]; then
+      cmd="${COMP_WORDS[i]}"
+      break
+    fi
+  done
+
+  if [[ "$cur" == -* ]] || [[ "$prev" != "ign" ]]; then
+
+    if [[ "$cmd" == "help" ]]; then
+      opts=$(ign --commands)
+    else
+      COMPREPLY=($(compgen -f  -- "${COMP_WORDS[${COMP_CWORD}]}" ))
+      complete -o filenames -o nospace -F "_ign" "ign"
+      return
+    fi
+
+  else
+    opts=$(ign --commands)
+  fi
+
+  COMPREPLY=($(compgen -W "${opts}" -- ${cur}))
+}
+complete -F "_ign" "ign"


### PR DESCRIPTION
# 🎉 New feature

Part of https://github.com/ignitionrobotics/ign-tools/issues/1.

## Summary

This adds a bash-completion helper based on the [script used by gazebo's `gz` command](https://github.com/osrf/gazebo/blob/gazebo11/tools/gazebo.bash-completion). It currently only autocompletes the names of `ign` commands using the output of `ign --commands`. Subsequent improvements may add support for autocompleting the `-*` arguments and ignition topic and service names. This pull request is intentionally simple to demonstrate the approach.

My goal is to emulate the approach taken by the [hub](https://github.com/github/hub) command, which hosts its own completion scripts in its [`etc` folder](https://github.com/github/hub/tree/master/etc). `hub` does not install these scripts with `make install` since the install location varies with each operating system distribution. Instead, the installation path is encoded in the [homebrew formula](https://github.com/Homebrew/homebrew-core/blob/aa2f643fd4215653c61d968ca54ff5c56b6f3da6/Formula/hub.rb#L34) and [debian metadata](https://sources.debian.org/src/hub/2.14.2%7Eds1-1/debian/hub.install/#L2). This enables `ign` autocompletion support on these two platforms if `bash-completion` is enabled without requiring additional user action. The debian metadata and homebrew formula can be updated with the next prerelease.

## Test it

Source the script in a terminal window and hit `<TAB>` after typing `ign ` and see the list of available commands.

To test a prototype of the homebrew formula, checkout https://github.com/osrf/homebrew-simulation/commit/38ae6c1063c38adbb66ba3995b184f5af8cc2c89 and install `ignition-tools` with the `--HEAD` flag. If `ignition-tools` has dependent packages already installed, use the following:

~~~
brew remove ignition-tools --ignore-dependencies
brew install --HEAD ignition-tools
~~~

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [X] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
