### PR TITLE
Don't install ruby-runn in CI

### DIFF
--- a/.github/ci/packages.apt
+++ b/.github/ci/packages.apt
@@ -1,2 +1,1 @@
-ruby-ronn
 rubocop


### PR DESCRIPTION
# 🦟 Bug fix

Follow-up to https://github.com/ignitionrobotics/ign-tools/pull/53, needed by #79 

## Summary

The `ruby-ronn` package isn't used anymore, as noted in #53, but it was still being installed in our CI. There's an error installing it in jammy in #79, so just remove it from `packages.apt` to complete the work of #53.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [X] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
