### PR TITLE
Revert "Remove configure.bat (#83)"

### DIFF
--- a/configure.bat
+++ b/configure.bat
@@ -1,0 +1,23 @@
+
+:: NOTE: This script is only meant to be used as part of the ignition developers' CI system
+:: Users and developers should build and install this library using cmake and Visual Studio
+
+:: Set configuration variables
+@set build_type=Release
+@if not "%1"=="" set build_type=%1
+@echo Configuring for build type %build_type%
+
+:: Use legacy install location if unset
+@if "%WORKSPACE_INSTALL_DIR%"=="" set WORKSPACE_INSTALL_DIR="install\%build_type%"
+
+:: Go to the directory that this configure.bat file exists in
+cd /d %~dp0
+
+:: Create a build directory and configure
+md build
+cd build
+cmake .. -G "NMake Makefiles" -DCMAKE_INSTALL_PREFIX="%WORKSPACE_INSTALL_DIR%" -DCMAKE_BUILD_TYPE="%build_type%" -DBUILD_TESTING:BOOL=False
+:: Note: We disable testing by default. If the intention is for the CI to build and test
+:: this project, then the CI script will turn it back on.
+
+:: If the caller wants to build and/or install, they should do so after calling this script


### PR DESCRIPTION
# 🦟 Bug fix

Reverts #83 to fix gazebo11 CI (a repeat of #66 and #76)

## Summary

Removing `configure.bat` breaks gazebo11 CI:

[![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gazebo-ci-gazebo11-windows7-amd64&build=140)](https://build.osrfoundation.org/job/gazebo-ci-gazebo11-windows7-amd64/140/) https://build.osrfoundation.org/job/gazebo-ci-gazebo11-windows7-amd64/140/

This reverts commit 73acac7ff186eea8f935a69f9c6485a826a9feca.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [X] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
