### PR TITLE
Fix typo in bash completion, add help completion

### DIFF
--- a/etc/ign.bash_completion.sh
+++ b/etc/ign.bash_completion.sh
@@ -30,6 +30,6 @@ function _ign
     opts=$(ign --commands)
   fi
 
-  COMPREPLY=($(compgen -W "${opts}" -- ${cur}))
+  COMPREPLY=($(compgen -W "${opts} help" -- ${cur}))
 }
 complete -F "_ign" "ign"

--- a/etc/ign.bash_completion.sh
+++ b/etc/ign.bash_completion.sh
@@ -27,9 +27,9 @@ function _ign
     fi
 
   else
-    opts=$(ign --commands)
+    opts="$(ign --commands) help"
   fi
 
-  COMPREPLY=($(compgen -W "${opts} help" -- ${cur}))
+  COMPREPLY=($(compgen -W "${opts}" -- ${cur}))
 }
 complete -F "_ign" "ign"

--- a/etc/ign.bash_completion.sh
+++ b/etc/ign.bash_completion.sh
@@ -10,7 +10,7 @@ function _ign
 
   # searching for the command
   for ((i=1; $i<=$COMP_CWORD; i++)); do
-    if [[ ${COMPWORDS[i]} != -* ]]; then
+    if [[ ${COMP_WORDS[i]} != -* ]]; then
       cmd="${COMP_WORDS[i]}"
       break
     fi


### PR DESCRIPTION
# 🦟 Bug fix

2 fixes before further changes to the file while working on #1. Original code #77.
- `COMPWORDS` is a typo
- `ign help` was not in tab completion. Now you can type `ign <tab>` and get `help` as a possible completion.

## Summary
Test with this:
```
. etc/ign.bash_completion.sh

# `help` should be listed as an available command after the PR
ign <tab>

# `help` should be auto completed
ign h<tab>
```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.